### PR TITLE
Add github links to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "version": "0.10.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dvargas92495/roam-marked.git"
+  },
+  "homepage": "https://github.com/dvargas92495/roam-marked",
   "scripts": {
     "prebuild": "npm t",
     "build": "ncc build src/index.ts -o dist",


### PR DESCRIPTION
For easier repo discovery from npm, which is especially valuable when the readme does not have docs.